### PR TITLE
Fix event status and message display

### DIFF
--- a/app/models/models.py
+++ b/app/models/models.py
@@ -63,7 +63,8 @@ class Event(db.Model):
             'context': self.context,
             'source': self.source,
             'severity': self.severity,
-            'status': self.event_status,
+            'event_status': self.event_status,
+            'status': self.event_status,  # backward compatibility
             'current_round': self.current_round,
             'created_at': self.created_at.isoformat() if self.created_at else None,
             'updated_at': self.updated_at.isoformat() if self.updated_at else None

--- a/app/static/js/warroom.js
+++ b/app/static/js/warroom.js
@@ -895,7 +895,7 @@ function addMessage(message) {
         messageContent += `<div class="llm-request-notification"><p>${requestContent}</p></div>`;
     } else if (message.message_type === 'llm_response') {
         const content = message.message_content;
-        let data = (content.type === 'llm_response') ? content.data : content;
+        let data = extractMessageData(content);
         if (message.message_from === '_captain') {
             if (data.response_type === 'TASK') {
                 messageContent += `<p>${data.response_text || '分配任务'}</p>`;
@@ -977,7 +977,7 @@ function addMessage(message) {
         }
     } else if (message.message_type === 'command_result') {
         const content = message.message_content;
-        let data = (content.type === 'command_result') ? content.data : content;
+        let data = extractMessageData(content);
         if (message.message_from === '_executor') {
             messageContent += `<p>命令 "${data.command_name}" 执行${data.status === 'completed' ? '成功' : '失败'}</p>`;
             if (data.ai_summary) {
@@ -995,7 +995,7 @@ function addMessage(message) {
         }
     } else if (message.message_type === 'execution_summary') {
         const content = message.message_content;
-        let data = (content.type === 'execution_summary') ? content.data : content;
+        let data = extractMessageData(content);
         if (message.message_from === '_expert' && data.ai_summary) {
             messageContent += `<p>执行结果摘要:</p><div class="ai-summary markdown-content">${marked.parse(data.ai_summary)}</div>`;
         } else {
@@ -1003,7 +1003,7 @@ function addMessage(message) {
         }
     } else if (message.message_type === 'event_summary') {
         const content = message.message_content;
-        let data = (content.type === 'event_summary') ? content.data : content;
+        let data = extractMessageData(content);
         if (message.message_from === '_expert') {
             messageContent += `<p>事件总结 (轮次 ${data.round_id}):</p><div class="event-summary markdown-content">${marked.parse(data.event_summary)}</div>`;
         } else {
@@ -1011,7 +1011,7 @@ function addMessage(message) {
         }
     } else if (message.message_type === 'system_notification') {
         const content = message.message_content;
-        let data = (content.type === 'system_notification') ? content.data : content;
+        let data = extractMessageData(content);
         messageContent += `<div class="system-notification"><p>${data.response_text}</p></div>`;
     } else {
         // 普通消息，确保 message.message_content 不是对象。如果是对象，尝试提取 data.text 或 stringify
@@ -1614,6 +1614,13 @@ function getSeverityText(severity) {
     };
     
     return severityMap[severity] || severity || '未知';
+}
+
+function extractMessageData(content) {
+    if (content && typeof content === 'object') {
+        return (content.data !== undefined) ? content.data : content;
+    }
+    return content;
 }
 
 function getMessageTypeText(type) {

--- a/changelog.md
+++ b/changelog.md
@@ -70,4 +70,8 @@
 - **配置项**: `main.py` 中的部分 Flask 和 SocketIO 配置（如日志开关、缓冲区大小）改为通过环境变量控制。
 
 ### 移除 (本次消息机制重大更新)
-- Agent 服务 (`captain`, `manager`, `operator`, `executor`, `expert`) 中对 `app.controllers.socket_controller.broadcast_message` 的直接调用及相关导入。 
+- Agent 服务 (`captain`, `manager`, `operator`, `executor`, `expert`) 中对 `app.controllers.socket_controller.broadcast_message` 的直接调用及相关导入。
+
+### 修复
+- 前端无法正确显示事件状态，因 `Event.to_dict()` 返回的字段名与前端期望不一致，现统一为 `event_status`，并保留 `status` 兼容旧代码。
+- 系统通知等消息内容显示 `undefined`，更新前端 `warroom.js` 使用统一的 `extractMessageData` 函数解析消息内容。


### PR DESCRIPTION
## Summary
- fix `Event.to_dict()` so API returns `event_status` for the front-end
- parse message content safely with new `extractMessageData` helper
- document the fixes in `changelog.md`

## Testing
- `python -m py_compile app/models/models.py`
