### PR TITLE
Add prompt management UI and API

### DIFF
--- a/app/controllers/__init__.py
+++ b/app/controllers/__init__.py
@@ -4,5 +4,6 @@ from flask import Blueprint
 from .event_controller import event_bp
 from .socket_controller import register_socket_events, broadcast_message
 from .auth_controller import auth_bp
+from .prompt_controller import prompt_bp
 
-__all__ = ['event_bp', 'register_socket_events', 'broadcast_message', 'auth_bp'] 
+__all__ = ['event_bp', 'register_socket_events', 'broadcast_message', 'auth_bp', 'prompt_bp']

--- a/app/controllers/prompt_controller.py
+++ b/app/controllers/prompt_controller.py
@@ -1,0 +1,57 @@
+import logging
+from pathlib import Path
+from flask import Blueprint, request, jsonify
+from flask_jwt_extended import jwt_required
+
+prompt_bp = Blueprint('prompt', __name__)
+logger = logging.getLogger(__name__)
+
+PROMPT_DIR = Path(__file__).parent.parent / 'prompts'
+ROLE_FILES = {
+    '_captain': 'role_soc_captain.md',
+    '_manager': 'role_soc_manager.md',
+    '_operator': 'role_soc_operator.md',
+    '_expert': 'role_soc_expert.md'
+}
+
+
+def _load_prompt(role: str) -> str:
+    file_path = PROMPT_DIR / ROLE_FILES[role]
+    if file_path.exists():
+        with open(file_path, 'r', encoding='utf-8') as f:
+            return f.read()
+    return ''
+
+
+def _save_prompt(role: str, content: str) -> None:
+    file_path = PROMPT_DIR / ROLE_FILES[role]
+    with open(file_path, 'w', encoding='utf-8') as f:
+        f.write(content)
+
+
+@prompt_bp.route('/list', methods=['GET'])
+@jwt_required()
+def list_prompts():
+    """Return prompts for all supported roles."""
+    prompts = {role: _load_prompt(role) for role in ROLE_FILES}
+    return jsonify({'status': 'success', 'data': prompts})
+
+
+@prompt_bp.route('/<role>', methods=['GET', 'PUT'])
+@jwt_required()
+def handle_prompt(role):
+    """Get or update prompt for a specific role."""
+    if role not in ROLE_FILES:
+        return jsonify({'status': 'error', 'message': '未知角色'}), 400
+
+    if request.method == 'GET':
+        return jsonify({'status': 'success', 'data': _load_prompt(role)})
+
+    data = request.get_json() or {}
+    content = data.get('prompt', '')
+    try:
+        _save_prompt(role, content)
+        return jsonify({'status': 'success', 'message': '保存成功'})
+    except Exception as e:
+        logger.error(f'保存提示词失败: {e}')
+        return jsonify({'status': 'error', 'message': '保存失败'}), 500

--- a/app/prompts/generate_prompt.py
+++ b/app/prompts/generate_prompt.py
@@ -1,81 +1,38 @@
 #!/usr/bin/env python3
+"""Utility to build prompts for different roles."""
+from pathlib import Path
 
-import os
-import sys
+PROMPT_DIR = Path(__file__).parent
+ROLE_FILES = {
+    '_captain': 'role_soc_captain.md',
+    '_manager': 'role_soc_manager.md',
+    '_operator': 'role_soc_operator.md',
+    '_expert': 'role_soc_expert.md'
+}
+
+BACKGROUND_FILE = PROMPT_DIR / 'background_security.md'
+PLAYBOOK_FILE = PROMPT_DIR / 'background_soar_playbooks.md'
 
 
-def generate_prompt_for_captain():
-    prompt_default = ""
-    with open("prompts/role_soc_captain.md", "r") as f:
-        prompt_default = f.read()
-
-    prompt_background = ""
-    with open("prompts/background_security.md", "r") as f:
-        prompt_background = f.read()
-
-    prompt = prompt_default.replace("{background_info}", prompt_background)
-
+def generate_prompt(role: str) -> str:
+    """Generate prompt text for the given role."""
+    role_file = PROMPT_DIR / ROLE_FILES.get(role, '')
+    if not role_file.exists():
+        return ''
+    background_info = BACKGROUND_FILE.read_text(encoding='utf-8') if BACKGROUND_FILE.exists() else ''
+    playbook_list = PLAYBOOK_FILE.read_text(encoding='utf-8') if PLAYBOOK_FILE.exists() else ''
+    prompt = role_file.read_text(encoding='utf-8')
+    prompt = prompt.replace('{background_info}', background_info)
+    prompt = prompt.replace('{playbook_list}', playbook_list)
     return prompt
 
 
-def generate_prompt_for_analyst():
-    prompt_default = ""
-    with open("prompts/role_soc_analyst.md", "r") as f:
-        prompt_default = f.read()
-
-    prompt_background = ""
-    with open("prompts/background_security.md", "r") as f:
-        prompt_background = f.read()
-
-    prompt_playbooks = ""
-    with open("prompts/background_soar_playbooks.md", "r") as f:
-        prompt_playbooks = f.read()
-
-    prompt = prompt_default.replace("{background_info}", prompt_background)
-    prompt = prompt.replace("{playbook_list}", prompt_playbooks)
-
-    return prompt
+def main():
+    for role in ROLE_FILES:
+        text = generate_prompt(role)
+        print(f"==== {role} ====")
+        print(text[:200] + ('...' if len(text) > 200 else ''))
 
 
-
-def generate_prompt_for_responder():
-    prompt_default = ""
-    with open("prompts/role_soc_responder.md", "r") as f:
-        prompt_default = f.read()
-
-    prompt_background = ""
-    with open("prompts/background_security.md", "r") as f:
-        prompt_background = f.read()
-
-    playbook_list = ""
-    with open("prompts/background_soar_playbooks.md", "r") as f:
-        playbook_list = f.read()
-
-    prompt = prompt_default.replace("{background_info}", prompt_background)
-    prompt = prompt.replace("{playbook_list}", playbook_list)
-
-    return prompt
-
-def generate_prompt_for_operator():
-    prompt_default = ""
-    with open("prompts/role_soc_operator.md", "r") as f:
-        prompt_default = f.read()
-
-    background_info = ""
-    with open("prompts/background_security.md", "r") as f:
-        background_info = f.read()
-
-    playbook_list = ""
-    with open("prompts/background_soar_playbooks.md", "r") as f:
-        playbook_list = f.read()
-
-    prompt = prompt_default.replace("{background_info}", background_info)
-    prompt = prompt.replace("{playbook_list}", playbook_list)
-
-    return prompt
-
-if __name__ == "__main__":
-    generate_prompt_for_commander()
-    generate_prompt_for_analyst()
-    generate_prompt_for_responder()
-    generate_prompt_for_operator()
+if __name__ == '__main__':
+    main()

--- a/app/static/js/index.js
+++ b/app/static/js/index.js
@@ -280,14 +280,17 @@ function updateAuthUI(isAuthenticated) {
     // 更新导航栏状态
     const loginNavItem = document.getElementById('login-nav-item');
     const userNavItem = document.getElementById('user-nav-item');
-    
+    const settingsNavItem = document.getElementById('settings-nav-item');
+
     if (loginNavItem && userNavItem) {
         if (isAuthenticated) {
             loginNavItem.classList.add('d-none');
             userNavItem.classList.remove('d-none');
+            if (settingsNavItem) settingsNavItem.classList.remove('d-none');
         } else {
             loginNavItem.classList.remove('d-none');
             userNavItem.classList.add('d-none');
+            if (settingsNavItem) settingsNavItem.classList.add('d-none');
         }
     }
 }

--- a/app/static/js/prompt_management.js
+++ b/app/static/js/prompt_management.js
@@ -1,0 +1,133 @@
+// 提示词管理页面脚本
+const API_BASE_URL = '/api';
+
+function getAuthHeaders() {
+    const token = localStorage.getItem('access_token') || getCookie('access_token');
+    return {
+        'Content-Type': 'application/json',
+        'Authorization': token ? `Bearer ${token}` : ''
+    };
+}
+
+function getCookie(name) {
+    const value = `; ${document.cookie}`;
+    const parts = value.split(`; ${name}=`);
+    if (parts.length === 2) return parts.pop().split(';').shift();
+    return null;
+}
+
+function showToast(message, type = 'info') {
+    const toastContainer = document.getElementById('toast-container');
+    const toast = document.createElement('div');
+    toast.className = `toast align-items-center text-white bg-${type === 'success' ? 'success' : type === 'error' ? 'danger' : 'primary'}`;
+    toast.setAttribute('role', 'alert');
+    toast.setAttribute('aria-live', 'assertive');
+    toast.setAttribute('aria-atomic', 'true');
+    toast.innerHTML = `
+        <div class="d-flex">
+            <div class="toast-body">${message}</div>
+            <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+        </div>`;
+    toastContainer.appendChild(toast);
+    const bsToast = new bootstrap.Toast(toast, { autohide: true, delay: 3000 });
+    bsToast.show();
+    toast.addEventListener('hidden.bs.toast', () => toast.remove());
+}
+
+function updateAuthUI(isAuthenticated) {
+    const loginNavItem = document.getElementById('login-nav-item');
+    const userNavItem = document.getElementById('user-nav-item');
+    const settingsNavItem = document.getElementById('settings-nav-item');
+    if (loginNavItem && userNavItem) {
+        if (isAuthenticated) {
+            loginNavItem.classList.add('d-none');
+            userNavItem.classList.remove('d-none');
+            if (settingsNavItem) settingsNavItem.classList.remove('d-none');
+        } else {
+            loginNavItem.classList.remove('d-none');
+            userNavItem.classList.add('d-none');
+            if (settingsNavItem) settingsNavItem.classList.add('d-none');
+        }
+    }
+}
+
+function checkAuth() {
+    const token = localStorage.getItem('access_token') || getCookie('access_token');
+    updateAuthUI(!!token);
+    if (token) {
+        fetch('/api/auth/check-auth', {
+            headers: { 'Authorization': `Bearer ${token}` },
+            credentials: 'include'
+        })
+        .then(r => r.json())
+        .then(data => {
+            if (!data.authenticated) {
+                localStorage.removeItem('access_token');
+                localStorage.removeItem('user_info');
+                document.cookie = 'access_token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
+                updateAuthUI(false);
+            }
+        })
+        .catch(() => {
+            localStorage.removeItem('access_token');
+            localStorage.removeItem('user_info');
+            document.cookie = 'access_token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
+            updateAuthUI(false);
+        });
+    }
+}
+
+function loadPrompts() {
+    fetch(`${API_BASE_URL}/prompt/list`, { headers: getAuthHeaders(), credentials: 'include' })
+        .then(r => r.json())
+        .then(data => {
+            if (data.status === 'success') {
+                const prompts = data.data;
+                for (const role in prompts) {
+                    const textarea = document.getElementById(`prompt-${role}`);
+                    if (textarea) textarea.value = prompts[role];
+                }
+            } else {
+                showToast(data.message || '加载失败', 'error');
+            }
+        })
+        .catch(() => showToast('加载失败', 'error'));
+}
+
+function savePrompt(role) {
+    const textarea = document.getElementById(`prompt-${role}`);
+    if (!textarea) return;
+    fetch(`${API_BASE_URL}/prompt/${role}`, {
+        method: 'PUT',
+        headers: getAuthHeaders(),
+        body: JSON.stringify({ prompt: textarea.value }),
+        credentials: 'include'
+    })
+        .then(r => r.json())
+        .then(data => {
+            if (data.status === 'success') {
+                showToast('保存成功', 'success');
+            } else {
+                showToast(data.message || '保存失败', 'error');
+            }
+        })
+        .catch(() => showToast('保存失败', 'error'));
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    checkAuth();
+    loadPrompts();
+    document.querySelectorAll('.save-prompt-btn').forEach(btn => {
+        btn.addEventListener('click', () => savePrompt(btn.dataset.role));
+    });
+    const logoutBtn = document.getElementById('logout-btn');
+    if (logoutBtn) logoutBtn.addEventListener('click', logout);
+});
+
+function logout() {
+    localStorage.removeItem('access_token');
+    localStorage.removeItem('user_info');
+    document.cookie = 'access_token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
+    showToast('已成功退出登录', 'info');
+    setTimeout(() => { window.location.href = '/login'; }, 1500);
+}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -23,6 +23,12 @@
                     <li class="nav-item">
                         <a class="nav-link active" href="/">首页</a>
                     </li>
+                    <li class="nav-item dropdown d-none" id="settings-nav-item">
+                        <a class="nav-link dropdown-toggle" href="#" id="settings-dropdown" role="button" data-bs-toggle="dropdown">设置</a>
+                        <ul class="dropdown-menu">
+                            <li><a class="dropdown-item" href="/settings/prompts">提示词管理</a></li>
+                        </ul>
+                    </li>
                 </ul>
                 <ul class="navbar-nav">
                     <!-- 登录前显示 -->

--- a/app/templates/prompt_management.html
+++ b/app/templates/prompt_management.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>提示词管理 - DeepSOC</title>
+    <link rel="stylesheet" href="/static/css/bootstrap.min.css">
+    <link rel="stylesheet" href="/static/css/style.css">
+</head>
+<body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary mb-4">
+        <div class="container">
+            <a class="navbar-brand d-flex align-items-center" href="/">
+                <img src="/static/images/logo/logo.png" alt="DeepSOC Logo" height="30" class="me-2">
+                DeepSOC
+            </a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarNav">
+                <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                    <li class="nav-item">
+                        <a class="nav-link" href="/">首页</a>
+                    </li>
+                    <li class="nav-item dropdown" id="settings-nav-item">
+                        <a class="nav-link dropdown-toggle active" href="#" id="settings-dropdown" role="button" data-bs-toggle="dropdown">设置</a>
+                        <ul class="dropdown-menu">
+                            <li><a class="dropdown-item active" href="/settings/prompts">提示词管理</a></li>
+                        </ul>
+                    </li>
+                </ul>
+                <ul class="navbar-nav">
+                    <li class="nav-item" id="login-nav-item">
+                        <a class="nav-link" href="/login">登录</a>
+                    </li>
+                    <li class="nav-item dropdown d-none" id="user-nav-item">
+                        <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown">
+                            <span id="user-info">用户</span>
+                        </a>
+                        <ul class="dropdown-menu dropdown-menu-end">
+                            <li><a class="dropdown-item" href="#" id="logout-btn">退出登录</a></li>
+                        </ul>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </nav>
+
+    <div class="container">
+        <h1 class="mb-4">提示词管理</h1>
+        <div id="prompt-container">
+            <div class="card mb-4">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <h5 class="mb-0">指挥官</h5>
+                    <button class="btn btn-sm btn-primary save-prompt-btn" data-role="_captain">保存</button>
+                </div>
+                <div class="card-body">
+                    <textarea class="form-control" rows="6" id="prompt-_captain"></textarea>
+                </div>
+            </div>
+            <div class="card mb-4">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <h5 class="mb-0">安全经理</h5>
+                    <button class="btn btn-sm btn-primary save-prompt-btn" data-role="_manager">保存</button>
+                </div>
+                <div class="card-body">
+                    <textarea class="form-control" rows="6" id="prompt-_manager"></textarea>
+                </div>
+            </div>
+            <div class="card mb-4">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <h5 class="mb-0">操作员</h5>
+                    <button class="btn btn-sm btn-primary save-prompt-btn" data-role="_operator">保存</button>
+                </div>
+                <div class="card-body">
+                    <textarea class="form-control" rows="6" id="prompt-_operator"></textarea>
+                </div>
+            </div>
+            <div class="card mb-4">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <h5 class="mb-0">安全专家</h5>
+                    <button class="btn btn-sm btn-primary save-prompt-btn" data-role="_expert">保存</button>
+                </div>
+                <div class="card-body">
+                    <textarea class="form-control" rows="6" id="prompt-_expert"></textarea>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div id="toast-container" class="toast-container position-fixed bottom-0 end-0 p-3"></div>
+
+    <script src="/static/js/bootstrap.bundle.min.js"></script>
+    <script src="/static/js/prompt_management.js"></script>
+</body>
+</html>

--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@
 - **引入 RabbitMQ 作为核心消息队列**：重构后端 Agent 服务与主 Web 服务之间的消息通知机制，实现异步化和解耦。
 - **`RabbitMQPublisher` 工具类 (`app/utils/mq_utils.py`)**: 为各 Agent 服务提供统一的消息发布接口，支持连接重试和持久化消息。
 - **`RabbitMQConsumer` 工具类 (`app/utils/mq_consumer.py`)**: 在主 Web 服务中实现，负责从 RabbitMQ 消费消息，支持连接重试和回调处理。
+- 新增提示词管理页面及相关 API，可在“设置”菜单下编辑各角色提示词
 - **Agent 服务消息发布集成**: 
     - `captain_service.py`、`manager_service.py`、`operator_service.py`、`executor_service.py`、`expert_service.py`（包括其多线程worker）均已集成 `RabbitMQPublisher`，在生成业务消息（如LLM请求/响应、任务/动作/命令创建、执行结果、摘要生成、事件状态变更等）后，将消息发布到 RabbitMQ。
 - **主 Web 服务消息消费与 WebSocket 推送**: 

--- a/main.py
+++ b/main.py
@@ -65,6 +65,9 @@ app.register_blueprint(event_bp, url_prefix='/api/event')
 from app.controllers.auth_controller import auth_bp
 app.register_blueprint(auth_bp, url_prefix='/api/auth')
 
+from app.controllers.prompt_controller import prompt_bp
+app.register_blueprint(prompt_bp, url_prefix='/api/prompt')
+
 from app.controllers.socket_controller import register_socket_events
 register_socket_events(socketio)
 
@@ -201,6 +204,11 @@ def login():
 @login_required
 def warroom(event_id):
     return render_template('warroom.html', event_id=event_id)
+
+@app.route('/settings/prompts')
+@login_required
+def prompt_settings():
+    return render_template('prompt_management.html')
 
 @app.route('/health')
 def health():


### PR DESCRIPTION
## Summary
- support editing role prompts via new `prompt` blueprint
- add prompt management page under Settings navigation
- tweak homepage navigation to expose Settings dropdown
- include helper script to generate prompts
- document changes in changelog

## Testing
- `python -m py_compile app/controllers/__init__.py app/controllers/prompt_controller.py main.py app/prompts/generate_prompt.py`
