### PR TITLE
Add password change support

### DIFF
--- a/app/static/js/change_password.js
+++ b/app/static/js/change_password.js
@@ -1,0 +1,95 @@
+// 修改密码页面脚本
+
+const API_BASE_URL = '/api';
+
+function getAuthHeaders() {
+    const token = localStorage.getItem('access_token') || getCookie('access_token');
+    return {
+        'Content-Type': 'application/json',
+        'Authorization': token ? `Bearer ${token}` : ''
+    };
+}
+
+function getCookie(name) {
+    const value = `; ${document.cookie}`;
+    const parts = value.split(`; ${name}=`);
+    if (parts.length === 2) return parts.pop().split(';').shift();
+    return null;
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    updateUserInfo();
+
+    const form = document.getElementById('change-password-form');
+    form.addEventListener('submit', e => {
+        e.preventDefault();
+
+        const oldPassword = document.getElementById('old-password').value;
+        const newPassword = document.getElementById('new-password').value;
+
+        fetch(`${API_BASE_URL}/auth/change-password`, {
+            method: 'POST',
+            headers: getAuthHeaders(),
+            body: JSON.stringify({ old_password: oldPassword, new_password: newPassword }),
+            credentials: 'include'
+        })
+        .then(response => response.json())
+        .then(data => {
+            if (data.status === 'success') {
+                showToast('密码修改成功，请重新登录', 'success');
+                setTimeout(() => { logout(); }, 1500);
+            } else {
+                showToast(data.message || '修改失败', 'error');
+            }
+        })
+        .catch(err => {
+            console.error('修改密码错误:', err);
+            showToast('网络错误，请稍后重试', 'error');
+        });
+    });
+
+    const logoutBtn = document.getElementById('logout-btn');
+    if (logoutBtn) logoutBtn.addEventListener('click', logout);
+});
+
+function updateUserInfo() {
+    const userInfoElement = document.getElementById('user-info');
+    if (userInfoElement) {
+        const userInfo = JSON.parse(localStorage.getItem('user_info') || '{}');
+        if (userInfo.username) {
+            userInfoElement.textContent = userInfo.username;
+        }
+    }
+}
+
+function showToast(message, type = 'info') {
+    const toastContainer = document.getElementById('toast-container');
+    const toast = document.createElement('div');
+    toast.className = `toast align-items-center text-white bg-${type === 'success' ? 'success' : type === 'error' ? 'danger' : 'primary'}`;
+    toast.setAttribute('role', 'alert');
+    toast.setAttribute('aria-live', 'assertive');
+    toast.setAttribute('aria-atomic', 'true');
+
+    toast.innerHTML = `
+        <div class="d-flex">
+            <div class="toast-body">
+                ${message}
+            </div>
+            <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+        </div>`;
+
+    toastContainer.appendChild(toast);
+
+    const bsToast = new bootstrap.Toast(toast, { autohide: true, delay: 3000 });
+    bsToast.show();
+
+    toast.addEventListener('hidden.bs.toast', () => { toast.remove(); });
+}
+
+function logout() {
+    localStorage.removeItem('access_token');
+    localStorage.removeItem('user_info');
+    document.cookie = 'access_token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
+    showToast('已成功退出登录', 'info');
+    setTimeout(() => { window.location.href = '/login'; }, 1500);
+}

--- a/app/templates/background_security.html
+++ b/app/templates/background_security.html
@@ -41,6 +41,7 @@
                             <span id="user-info">用户</span>
                         </a>
                         <ul class="dropdown-menu dropdown-menu-end">
+                            <li><a class="dropdown-item" href="/change-password">修改密码</a></li>
                             <li><a class="dropdown-item" href="#" id="logout-btn">退出登录</a></li>
                         </ul>
                     </li>

--- a/app/templates/change_password.html
+++ b/app/templates/change_password.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>修改密码 - DeepSOC</title>
+    <link rel="stylesheet" href="/static/css/bootstrap.min.css">
+    <link rel="stylesheet" href="/static/css/style.css">
+</head>
+<body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary mb-4">
+        <div class="container">
+            <a class="navbar-brand d-flex align-items-center" href="/">
+                <img src="/static/images/logo/logo.png" alt="DeepSOC Logo" height="30" class="me-2">
+                DeepSOC
+            </a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarNav">
+                <ul class="navbar-nav me-auto mb-2 mb-lg-0"></ul>
+                <ul class="navbar-nav">
+                    <li class="nav-item dropdown" id="user-nav-item">
+                        <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown">
+                            <span id="user-info">用户</span>
+                        </a>
+                        <ul class="dropdown-menu dropdown-menu-end">
+                            <li><a class="dropdown-item" href="/change-password">修改密码</a></li>
+                            <li><a class="dropdown-item" href="#" id="logout-btn">退出登录</a></li>
+                        </ul>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </nav>
+
+    <div class="container" style="max-width: 500px;">
+        <h3 class="mb-4 text-center">修改密码</h3>
+        <form id="change-password-form">
+            <div class="mb-3">
+                <label for="old-password" class="form-label">旧密码</label>
+                <input type="password" class="form-control" id="old-password" required>
+            </div>
+            <div class="mb-3">
+                <label for="new-password" class="form-label">新密码</label>
+                <input type="password" class="form-control" id="new-password" required>
+            </div>
+            <button type="submit" class="btn btn-primary w-100">提交</button>
+        </form>
+    </div>
+
+    <div id="toast-container" class="toast-container position-fixed bottom-0 end-0 p-3"></div>
+
+    <script src="/static/js/bootstrap.bundle.min.js"></script>
+    <script src="/static/js/change_password.js"></script>
+</body>
+</html>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -45,6 +45,7 @@
                             <span id="user-info">用户</span>
                         </a>
                         <ul class="dropdown-menu dropdown-menu-end">
+                            <li><a class="dropdown-item" href="/change-password">修改密码</a></li>
                             <li><a class="dropdown-item" href="#" id="logout-btn">退出登录</a></li>
                         </ul>
                     </li>

--- a/app/templates/mcp_tools.html
+++ b/app/templates/mcp_tools.html
@@ -41,6 +41,7 @@
                             <span id="user-info">用户</span>
                         </a>
                         <ul class="dropdown-menu dropdown-menu-end">
+                            <li><a class="dropdown-item" href="/change-password">修改密码</a></li>
                             <li><a class="dropdown-item" href="#" id="logout-btn">退出登录</a></li>
                         </ul>
                     </li>

--- a/app/templates/prompt_management.html
+++ b/app/templates/prompt_management.html
@@ -41,6 +41,7 @@
                             <span id="user-info">用户</span>
                         </a>
                         <ul class="dropdown-menu dropdown-menu-end">
+                            <li><a class="dropdown-item" href="/change-password">修改密码</a></li>
                             <li><a class="dropdown-item" href="#" id="logout-btn">退出登录</a></li>
                         </ul>
                     </li>

--- a/app/templates/soar_playbooks.html
+++ b/app/templates/soar_playbooks.html
@@ -41,6 +41,7 @@
                             <span id="user-info">用户</span>
                         </a>
                         <ul class="dropdown-menu dropdown-menu-end">
+                            <li><a class="dropdown-item" href="/change-password">修改密码</a></li>
                             <li><a class="dropdown-item" href="#" id="logout-btn">退出登录</a></li>
                         </ul>
                     </li>

--- a/changelog.md
+++ b/changelog.md
@@ -84,4 +84,5 @@
 - 提示词管理页面改为左侧导航布局，支持切换各角色及背景信息编辑。
 - 新增API `GET/PUT /api/prompt/background/<name>` 用于管理背景文件。
 - `PromptService` 采用 `generate_prompt` 动态生成提示词。
+- 新增修改密码页面及 `/api/auth/change-password` 接口，用户可在登录后通过右上角菜单修改密码。
 

--- a/main.py
+++ b/main.py
@@ -228,6 +228,11 @@ def soar_playbooks():
 def mcp_tools():
     return render_template('mcp_tools.html')
 
+@app.route('/change-password')
+@login_required
+def change_password_page():
+    return render_template('change_password.html')
+
 @app.route('/health')
 def health():
     return jsonify({


### PR DESCRIPTION
## Summary
- implement `/api/auth/change-password` API
- add change password page and JS
- expose change password link in top-right user menu
- route to render page via `/change-password`
- document feature in changelog

## Testing
- `python -m py_compile main.py app/controllers/auth_controller.py`
