### PR TITLE
Implement user chat broadcasting

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,11 @@ python tools/run_all_agents.py
 
 ![](app/static/images/deepsoc-warroom.jpg)
 
+### 在作战室发送消息
+
+作战室页面支持用户输入文本指令。发送的消息会通过 WebSocket 实时广播给所有在线用户，
+并以蓝色背景靠右显示，便于区分。
+
 ### 查看消息原始数据结构
 
 ![](app/static/images/deepsoc-warroom-message-structure.jpg)

--- a/app/controllers/event_controller.py
+++ b/app/controllers/event_controller.py
@@ -185,13 +185,19 @@ def send_message(event_id):
             'message': '事件不存在'
         }), 404
     
-    # 创建消息
+    # 创建消息，支持扩展不同类型的内容
+    content_type = data.get('content_type', 'text')
+    message_content = {
+        'type': content_type,
+        'text': data.get('message')
+    }
+
     message = Message(
         message_id=str(uuid.uuid4()),
         event_id=event_id,
         message_from=data.get('sender', 'user'),
         message_type='user_message',
-        message_content=data.get('message')
+        message_content=message_content
     )
     
     # 广播消息

--- a/app/static/css/warroom.css
+++ b/app/static/css/warroom.css
@@ -237,10 +237,14 @@ h1, h2, h3, h4, h5, h6, .cyber-btn, .section-title, .status-label {
 
 .message-user {
     border-left: none;
-    border-right: 3px solid #607d8b;
-    background-color: rgba(96, 125, 139, 0.15);
+    border-right: 3px solid var(--info-color);
+    background-color: rgba(0, 168, 255, 0.15);
     align-self: flex-end;
     margin-left: auto;
+}
+
+.message-user .message-sender {
+    color: var(--info-color);
 }
 
 .message-header {

--- a/app/static/js/warroom.js
+++ b/app/static/js/warroom.js
@@ -1070,14 +1070,15 @@ function toggleCollapsible(id) {
 
 // 发送消息
 async function sendMessage() {
-    const messageInput = document.getElementById('user-message');
+    // 使用统一的输入框，预留扩展空间
+    const messageInput = elements.userInput;
     const message = messageInput.value.trim();
     
     if (!message) return;
     
     try {
         // 禁用发送按钮
-        const sendButton = document.getElementById('send-message-btn');
+        const sendButton = elements.sendButton;
         sendButton.disabled = true;
         
         const response = await fetch(`/api/event/send_message/${eventId}`, {
@@ -1085,7 +1086,8 @@ async function sendMessage() {
             headers: getAuthHeaders(),
             body: JSON.stringify({
                 message: message,
-                sender: 'user'
+                sender: 'user',
+                content_type: 'text' // 未来可扩展为 voice、image、file 等
             }),
             credentials: 'include'
         });
@@ -1112,7 +1114,7 @@ async function sendMessage() {
         showToast('网络错误，请稍后重试', 'error');
     } finally {
         // 启用发送按钮
-        const sendButton = document.getElementById('send-message-btn');
+        const sendButton = elements.sendButton;
         sendButton.disabled = false;
     }
 }

--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,7 @@
 - 新增 `prompts` 数据表，用于存储所有提示词和背景信息，前端可在线修改
 - 初始化脚本现会自动导入内置的提示词，并移除相应 Markdown 模板文件
 - 初始化脚本支持从 `initial_data.sql` 导入示例数据，安装后即可体验
+- 作战室支持用户发送文本消息，并通过 WebSocket 广播给其他在线用户，用户消息在界面右侧以蓝色高亮显示
 - **Agent 服务消息发布集成**: 
     - `captain_service.py`、`manager_service.py`、`operator_service.py`、`executor_service.py`、`expert_service.py`（包括其多线程worker）均已集成 `RabbitMQPublisher`，在生成业务消息（如LLM请求/响应、任务/动作/命令创建、执行结果、摘要生成、事件状态变更等）后，将消息发布到 RabbitMQ。
 - **主 Web 服务消息消费与 WebSocket 推送**: 


### PR DESCRIPTION
## Summary
- allow user messages to carry `content_type` for future media support
- connect the War Room input field to message sending
- style user messages with blue accent on the right side
- document how to send chat messages
- note the new feature in changelog

## Testing
- `python -m py_compile app/controllers/event_controller.py`