### PR TITLE
Mcp client failure investigation

### DIFF
--- a/app/mcp/client_manager.py
+++ b/app/mcp/client_manager.py
@@ -29,6 +29,18 @@ class MCPClientManager:
             return await client.list_tools()
 
     async def _call_tool_async(self, url, tool_name, arguments):
+        """
+        执行 MCP 工具调用
+        
+        注意：FastMCP Client.call_tool() 的签名是：
+            call_tool(name: str, arguments: dict | None = None, ...)
+        参数应该作为 dict 传入，而不是展开为 **kwargs
+        
+        Args:
+            url: MCP 服务器 URL
+            tool_name: 工具名称
+            arguments: 工具参数字典
+        """
         # 使用 Client(url) 上下文管理器时，fastmcp 会自动处理连接和断开
         # 如果服务器不支持 DELETE，断开时可能会报错，我们需要捕获这个错误
         # 以免影响工具调用的结果返回
@@ -37,8 +49,8 @@ class MCPClientManager:
         client = Client(url)
         try:
             await client.__aenter__()
-            # Call tool
-            result = await client.call_tool(tool_name, **arguments)
+            # Call tool - 注意：arguments 作为 dict 传入，不是 **arguments
+            result = await client.call_tool(tool_name, arguments)
             return result
         except Exception as e:
             logger.error(f"Error calling tool {tool_name}: {e}")

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 2025-12-18 (Update 2)
+### Bug Fixes
+- **MCP Client call_tool 参数修复**:
+  - 修复了 FastMCP `call_tool()` 方法的调用方式错误，参数应该作为 `dict` 传入而不是 `**kwargs` 展开。
+  - 更新 `app/mcp/client_manager.py` 中的 `_call_tool_async()` 方法，使用正确的签名 `call_tool(name, arguments)`。
+  
+- **测试脚本优化** (`tests/test_mcp_client.py`):
+  - 重写测试脚本，增加优雅的会话关闭错误处理（405 错误是良性的，不影响功能）。
+  - 降低 httpx/mcp/fastmcp 库的日志级别，减少冗余输出。
+  - 新增 `--call-tool` 参数支持工具调用测试。
+  - 优化输出格式，显示工具参数详情和 JSON 格式化结果。
+
+### 说明
+- **405 Method Not Allowed 问题解释**：某些 MCP 服务器（Streamable HTTP 模式）不支持 DELETE 方法关闭会话，FastMCP 在退出时会尝试发送 DELETE 请求导致 405 错误。这是良性错误，不影响功能。Cherry Studio 等工具也会遇到同样问题，只是隐藏了错误日志。
+- 代码现在优雅处理这个错误，测试输出更加清晰。
+
+---
+
 ## 2025-12-18
 ### Bug Fixes
 - **MCP Client 重构 (Use FastMCP)**:

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -1,14 +1,85 @@
+"""
+MCP Client 测试脚本
+
+功能说明：
+1. 测试与 MCP 服务器的连接
+2. 列出服务器上的所有工具
+3. 可选：调用工具进行测试
+
+使用方法：
+    python tests/test_mcp_client.py                    # 默认只列出工具
+    python tests/test_mcp_client.py --call-tool        # 列出工具并调用测试
+
+注意：
+- 某些 MCP 服务器 (Streamable HTTP 模式) 不支持 DELETE 方法关闭会话
+- 这会导致 405 错误，但这是良性的，不影响功能
+- Cherry Studio 等工具也会遇到同样的问题，只是它们隐藏了这个错误
+"""
+
 import asyncio
 import logging
 import os
+import sys
 import json
 from fastmcp import Client
 
-# Configure logging to see what's happening
+# Configure logging - 减少 httpx 的冗余输出
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
 
-async def test_fastmcp_client():
+# 降低 httpx 的日志级别，避免显示每个 HTTP 请求（包括 405 错误）
+logging.getLogger("httpx").setLevel(logging.WARNING)
+logging.getLogger("httpcore").setLevel(logging.WARNING)
+# 降低 mcp 相关库的日志级别
+logging.getLogger("mcp").setLevel(logging.WARNING)
+logging.getLogger("fastmcp").setLevel(logging.WARNING)
+
+
+async def safe_mcp_client_call(url, operation_fn):
+    """
+    安全地执行 MCP 客户端操作，优雅处理关闭时的 405 错误
+    
+    Args:
+        url: MCP 服务器 URL
+        operation_fn: 异步函数，接收 client 参数，执行实际操作
+    
+    Returns:
+        operation_fn 的返回值
+    """
+    client = Client(url)
+    try:
+        await client.__aenter__()
+        return await operation_fn(client)
+    finally:
+        try:
+            await client.__aexit__(None, None, None)
+        except Exception as e:
+            # 某些 MCP 服务器不支持 DELETE 方法关闭会话，这是良性错误
+            if "405" in str(e):
+                logger.debug(f"Session cleanup returned 405 (benign): {e}")
+            else:
+                logger.warning(f"Error closing MCP session: {e}")
+
+
+async def list_tools(client):
+    """列出所有工具"""
+    tools = await client.list_tools()
+    return tools
+
+
+async def call_tool(client, tool_name, arguments):
+    """
+    调用工具
+    
+    注意：FastMCP Client.call_tool() 的签名是：
+        call_tool(name: str, arguments: dict | None = None, ...)
+    参数应该作为 dict 传入，而不是展开为 **kwargs
+    """
+    result = await client.call_tool(tool_name, arguments)
+    return result
+
+
+async def test_fastmcp_client(call_test_tool=False):
     # 测试配置 (默认使用提供的USG防火墙配置)
     DEFAULT_BASE_URL = "https://mcp.51pwd.com/Firewall/USGFirewall"
     DEFAULT_TOKEN = "75cef760-a70d-412e-8481-fdc699e4c7d8"
@@ -19,53 +90,93 @@ async def test_fastmcp_client():
     print(f"\n--- Testing MCP Server with FastMCP: {base_url} ---")
     
     try:
-        # FastMCP Client context manager handles connection and cleanup
-        async with Client(base_url) as client:
-            print("\n--- Connected! ---")
+        # 1. 列出工具
+        print("\n--- Listing Tools ---")
+        tools = await safe_mcp_client_call(base_url, list_tools)
+        
+        if tools:
+            print(f"\n✅ 连接成功！找到 {len(tools)} 个工具:")
+            for tool in tools:
+                print(f"  - {tool.name}: {tool.description}")
+                
+                # 获取参数 schema
+                if hasattr(tool, 'inputSchema') and tool.inputSchema:
+                    schema = tool.inputSchema
+                    properties = schema.get('properties', {})
+                    required = schema.get('required', [])
+                    if properties:
+                        print(f"    参数:")
+                        for param_name, param_info in properties.items():
+                            required_mark = " (必填)" if param_name in required else ""
+                            param_type = param_info.get('type', 'unknown')
+                            param_desc = param_info.get('description', '')
+                            print(f"      - {param_name}: {param_type}{required_mark} - {param_desc}")
+        else:
+            print("❌ 未找到任何工具")
+            return
+        
+        # 2. 可选：调用工具测试
+        if call_test_tool and tools:
+            print("\n--- Testing Tool Call ---")
+            # 选择 unblock_ip_address 工具进行测试（解封操作比较安全）
+            test_tool = None
+            for tool in tools:
+                if tool.name == 'unblock_ip_address':
+                    test_tool = tool
+                    break
             
-            print("\n--- Listing Tools ---")
-            tools = await client.list_tools()
-            if tools:
-                print(f"Found {len(tools)} tools:")
-                for tool in tools:
-                    # FastMCP Tool object
-                    print(f"  - {tool.name}: {tool.description}")
-                    
-                    # 检查 parameters 属性
-                    # FastMCP 2.x 的 Tool 对象可能结构有所不同
-                    # 在 mcp 库中，Tool 对象的 inputSchema 属性存储了参数定义
-                    # 而 FastMCP 对此进行了封装，可能是 parameters, args_schema, 或者其他
-                    
-                    # 尝试打印对象的所有属性以进行调试
-                    # print(f"    Tool Attributes: {dir(tool)}")
-                    
-                    if hasattr(tool, 'inputSchema'):
-                        schema = tool.inputSchema
-                        # print(f"    Schema (inputSchema): {json.dumps(schema, ensure_ascii=False)}")
-                    elif hasattr(tool, 'parameters'):
-                         # 之前的代码假设是 parameters 并且是 Pydantic 模型
-                         # 如果是 dict，直接使用
-                         if isinstance(tool.parameters, dict):
-                             schema = tool.parameters
-                         elif hasattr(tool.parameters, 'model_json_schema'):
-                             schema = tool.parameters.model_json_schema()
-                         else:
-                             # print(f"    Parameters (unknown type): {type(tool.parameters)}")
-                             schema = {}
-                    else:
-                        print("    No parameters/schema found")
-                        schema = {}
-
+            if test_tool:
+                test_ip = "8.8.8.8"  # 使用一个测试 IP
+                print(f"\n调用工具: {test_tool.name}")
+                print(f"参数: ip_address={test_ip}")
+                
+                async def call_test(client):
+                    return await call_tool(client, test_tool.name, {"ip_address": test_ip})
+                
+                result = await safe_mcp_client_call(base_url, call_test)
+                
+                print(f"\n✅ 工具调用成功!")
+                print(f"结果:")
+                # FastMCP 返回 CallToolResult 对象，包含 content 列表
+                if hasattr(result, 'content'):
+                    for item in result.content:
+                        if hasattr(item, 'text'):
+                            # 尝试格式化 JSON 输出
+                            try:
+                                parsed = json.loads(item.text)
+                                print(f"  {json.dumps(parsed, ensure_ascii=False, indent=2)}")
+                            except json.JSONDecodeError:
+                                print(f"  {item.text}")
+                        else:
+                            print(f"  {item}")
+                elif isinstance(result, list):
+                    for item in result:
+                        if hasattr(item, 'text'):
+                            print(f"  {item.text}")
+                        else:
+                            print(f"  {item}")
+                else:
+                    print(f"  {result}")
             else:
-                print("No tools found.")
+                print("⚠️ 未找到 unblock_ip_address 工具，跳过调用测试")
+                
+        print("\n--- 测试完成 ---")
                 
     except Exception as e:
         logger.error(f"Test failed: {e}")
         import traceback
         traceback.print_exc()
 
+
 if __name__ == "__main__":
+    # 检查是否要调用工具测试
+    call_test = "--call-tool" in sys.argv or "-c" in sys.argv
+    
+    if "--help" in sys.argv or "-h" in sys.argv:
+        print(__doc__)
+        sys.exit(0)
+    
     try:
-        asyncio.run(test_fastmcp_client())
+        asyncio.run(test_fastmcp_client(call_test_tool=call_test))
     except KeyboardInterrupt:
         pass


### PR DESCRIPTION
Fix `FastMCP.call_tool()` argument passing and enhance `mcp_client` test script for robustness and clarity.

The `call_tool()` method was incorrectly spreading arguments as `**kwargs` instead of passing them as a single dictionary, which is the expected signature for `FastMCP.Client.call_tool()`. Additionally, the test script was failing due to a benign 405 "Method Not Allowed" error when the FastMCP client attempted to send a DELETE request to close the session, a behavior not supported by all MCP servers (e.g., Streamable HTTP mode). This PR addresses both issues by correcting the `call_tool()` signature and making the test script gracefully handle the 405 error, reduce log noise, and properly test tool invocation.

---
<a href="https://cursor.com/background-agent?bcId=bc-789b96e4-1b5e-4808-850a-30f8bd5199e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-789b96e4-1b5e-4808-850a-30f8bd5199e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

